### PR TITLE
Improve download CTA, diagnostic summary labels, and focus visibility

### DIFF
--- a/frontend/public/documents/programme-ls.pdf
+++ b/frontend/public/documents/programme-ls.pdf
@@ -1,0 +1,81 @@
+%PDF-1.3
+3 0 obj
+<</Type /Page
+/Parent 1 0 R
+/Resources 2 0 R
+/Contents 4 0 R>>
+endobj
+4 0 obj
+<</Filter /FlateDecode /Length 290>>
+stream
+xmAN0E=Ŭl4͖J ؛d5vEqB,YUvT
+Mem[v0<ތp/U uo$yͶ؈lgO6hVَ(/hP-+w&Oo	Z6KLx	e>I{?_Ze~%Ιt.;s5(LUֺg
+ﳢޮEsu80ɧIq^q=u!TlTd
+endstream
+endobj
+1 0 obj
+<</Type /Pages
+/Kids [3 0 R ]
+/Count 1
+/MediaBox [0 0 595.28 841.89]
+>>
+endobj
+5 0 obj
+<</Type /Font
+/BaseFont /Helvetica-Bold
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+6 0 obj
+<</Type /Font
+/BaseFont /Helvetica
+/Subtype /Type1
+/Encoding /WinAnsiEncoding
+>>
+endobj
+2 0 obj
+<<
+/ProcSet [/PDF /Text /ImageB /ImageC /ImageI]
+/Font <<
+/F1 5 0 R
+/F2 6 0 R
+>>
+/XObject <<
+>>
+>>
+endobj
+7 0 obj
+<<
+/Producer (PyFPDF 1.7.2 http://pyfpdf.googlecode.com/)
+/CreationDate (D:20250929221139)
+>>
+endobj
+8 0 obj
+<<
+/Type /Catalog
+/Pages 1 0 R
+/OpenAction [3 0 R /FitH null]
+/PageLayout /OneColumn
+>>
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000447 00000 n 
+0000000731 00000 n 
+0000000009 00000 n 
+0000000087 00000 n 
+0000000534 00000 n 
+0000000635 00000 n 
+0000000845 00000 n 
+0000000954 00000 n 
+trailer
+<<
+/Size 9
+/Root 8 0 R
+/Info 7 0 R
+>>
+startxref
+1057
+%%EOF

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -116,6 +116,12 @@
   color: var(--color-text-muted);
 }
 
+.primary-nav a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+  border-radius: 8px;
+}
+
 .primary-nav a.active,
 .primary-nav a:hover {
   color: var(--color-secondary);
@@ -144,6 +150,11 @@
   justify-content: center;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
   text-decoration: none;
+}
+
+.button:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 3px;
 }
 
 .button.primary {
@@ -189,6 +200,31 @@
   color: var(--color-secondary);
   padding: 0;
   border-radius: 0;
+}
+
+.hero-inline-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.75rem;
+  font-weight: 500;
+  color: var(--color-secondary);
+}
+
+.hero-inline-link::after {
+  content: '→';
+  font-size: 0.9em;
+}
+
+.hero-inline-link:hover {
+  color: var(--color-primary);
+}
+
+.hero-inline-link:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+  border-radius: 6px;
+  text-decoration: none;
 }
 
 .page {

--- a/frontend/src/pages/DiagnosticPage.jsx
+++ b/frontend/src/pages/DiagnosticPage.jsx
@@ -42,6 +42,24 @@ const steps = [
   },
 ]
 
+const fieldLabels = {
+  sector: "Secteur d'activité",
+  revenue: "Chiffre d'affaires",
+  teamSize: "Taille de l'équipe commerciale",
+  location: 'Lieu souhaité',
+  objectives: 'Objectifs sur 90 jours',
+  blockers: 'Freins identifiés',
+  timeline: 'Horizon de mise en place',
+  financing: 'Financement / OPCO',
+  decisionTime: 'Délai de décision',
+  notes: 'Notes complémentaires',
+  name: 'Nom et prénom',
+  role: 'Fonction',
+  email: 'Email',
+  phone: 'Téléphone',
+  consent: 'Consentement RGPD',
+}
+
 export default function DiagnosticPage() {
   usePageTitle('Diagnostic gratuit')
   const [stepIndex, setStepIndex] = useState(0)
@@ -115,7 +133,7 @@ export default function DiagnosticPage() {
             <dl>
               {Object.entries(formData).map(([field, value]) => (
                 <div key={field}>
-                  <dt>{field}</dt>
+                  <dt>{fieldLabels[field] ?? field}</dt>
                   <dd>{typeof value === 'boolean' ? (value ? 'Oui' : 'Non') : value || '—'}</dd>
                 </div>
               ))}

--- a/frontend/src/pages/HomePage.jsx
+++ b/frontend/src/pages/HomePage.jsx
@@ -113,10 +113,13 @@ export default function HomePage() {
               <Link className="button primary" to="/diagnostic">
                 Demander un diagnostic gratuit
               </Link>
-              <a className="button ghost" href="#programme">
+              <a className="button ghost" href="/documents/programme-ls.pdf" download>
                 Télécharger le programme
               </a>
             </div>
+            <a className="hero-inline-link" href="#programme">
+              Voir le programme en détail
+            </a>
             <ul className="hero-benefits">
               <li>Format hybride : distanciel + présentiel</li>
               <li>Éligible OPCO / Qualiopi</li>


### PR DESCRIPTION
## Summary
- add a downloadable programme PDF and supplemental anchor link in the hero
- map diagnostic recap fields to friendly French labels after submission
- introduce consistent focus-visible states for navigation links, buttons, and the new inline hero link

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dafc68b8a48331b71b9738dc0905fb